### PR TITLE
Rework gaussian

### DIFF
--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -6,7 +6,7 @@ import numpy as np
 from nessai.livepoint import numpy_array_to_live_points, live_points_to_array
 import pytest
 from scipy.stats import multivariate_normal
-from unittest.mock import create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 from nessai_models import Gaussian
 from nessai_models.gaussian import compute_gaussian_ln_evidence
@@ -17,28 +17,87 @@ def model():
     return create_autospec(Gaussian)
 
 
-@pytest.fixture
-def points(request):
-    n = request.param
-    x = 20 * np.random.rand(10, n) - 10
-    return numpy_array_to_live_points(x, [f'x_{i}' for i in range(n)])
-
-
 def test_init(model):
     """Test the init method"""
-    with patch('nessai_models.base.NDimensionalModel.__init__') as m:
-        Gaussian.__init__(model, 2, [-5, 5])
+    model.dims = 2
+    with patch('nessai_models.base.NDimensionalModel.__init__') as m, \
+         patch(
+            'nessai_models.gaussian.compute_gaussian_ln_evidence',
+            return_value=1.0
+        ) as m1:
+        Gaussian.__init__(model, 2, [-5, 5], normalise=True)
     m.assert_called_once_with(2, [-5, 5])
+    m1.assert_called_once_with([-5, 5], dims=2)
+    assert model.ln_evidence == 1.0
+    assert model._norm_const == 1.0
 
 
-@pytest.mark.parametrize('points', [2, 4, 8], indirect=True)
-def test_log_likelihood(model, points):
+def test_init_normalise_false(model):
+    """Assert the normalisation constant is zero when normalise is False"""
+    model.dims = 2
+    Gaussian.__init__(model, 2, [-5, 5], normalise=False, cov=None, mean=None)
+    assert model._norm_const == 0.0
+
+
+def test_init_cannot_normalise(model):
+    """Assert the normalisation constant is zero if normalisation is not
+    possible.
+    """
+    mean = 1
+    cov = np.eye(2)
+    model.dims = 2
+    with pytest.warns(Warning) as warninfo:
+        Gaussian.__init__(
+            model, 2, [-5, 5], mean=mean, cov=cov, normalise=True
+        )
+    assert model._norm_const == 0.0
+    assert "Cannot normalise" in str(warninfo[0].message)
+
+
+@pytest.mark.parametrize(
+    "mean, expected",
+    [
+        (None, np.zeros(2)),
+        (2.0, np.array([2, 2])),
+        (np.array([2, 2]), np.array([2, 2])),
+    ]
+)
+def test_init_mean(model, mean, expected):
+    """Assert the mean is set correctly"""
+    model.dims = len(expected)
+    Gaussian.__init__(model, len(expected), [-5, 5], mean=mean)
+    np.testing.assert_equal(model.mean, expected)
+
+
+@pytest.mark.parametrize(
+    "cov, expected",
+    [
+        (None, np.eye(2)),
+        (np.eye(2), np.eye(2)),
+    ]
+)
+def test_init_cov(model, cov, expected):
+    """Assert the covariance is set correctly"""
+    model.dims = len(expected)
+    Gaussian.__init__(model, len(expected), [-5, 5], cov=cov)
+    np.testing.assert_equal(model.cov, expected)
+
+
+def test_log_likelihood(model):
     """Test the log-likelihood"""
-    model.names = list(points.dtype.names[:-3])
-    log_l = Gaussian.log_likelihood(model, points)
-    x = live_points_to_array(points, names=model.names)
-    target = multivariate_normal(mean=len(model.names) * [0]).logpdf(x)
-    np.testing.assert_array_almost_equal(log_l, target)
+    x = np.random.randn(4, 2)
+    x_view = np.random.randn(4, 2)
+    log_l = np.array([1, 2, 3, 4])
+    model.unstructured_view = MagicMock(return_value=x_view)
+    model.dist = MagicMock()
+    model.dist.logpdf = MagicMock(return_value=log_l)
+    model._norm_const = 1
+
+    out = Gaussian.log_likelihood(model, x)
+    np.testing.assert_equal(out, np.array([0, 1, 2, 3]))
+
+    model.unstructured_view.assert_called_once_with(x)
+    model.dist.logpdf.assert_called_once_with(x_view)
 
 
 @pytest.mark.parametrize(
@@ -53,3 +112,17 @@ def test_gaussian_ln_evidence(dims, bounds, expected):
     """Assert the correct log evidence is returned."""
     out = compute_gaussian_ln_evidence(bounds, dims)
     assert expected == out
+
+
+def test_gaussian_ln_evidence_dims_error():
+    """Assert an error is raised if the bounds are 1-d and dims is None."""
+    with pytest.raises(ValueError) as excinfo:
+        compute_gaussian_ln_evidence([-5, 5])
+    assert "dims must be specified" in str(excinfo.value)
+
+
+def test_gaussian_ln_evidence_dims_wrong():
+    """Assert an error is raised if the dims and bounds do not agree."""
+    with pytest.raises(ValueError) as excinfo:
+        compute_gaussian_ln_evidence(np.array([[-5, 5], [-5, 5]]), 3)
+    assert "dims must match the first dimension" in str(excinfo.value)


### PR DESCRIPTION
Rework the `Gaussian` model to allow for specifying the mean and covariance. Also, compute the ln-evidence and, optionally, use this to normalise the log-likelihood.

Tests updated for changes.