### PR TITLE
Add signal plus noise models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add models for linear and sinusoidal signals in Gaussian noise.
+
 ## [0.1.0] - 2022-09-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Models for use with the nested sampling package [`nessai`](https://github.com/mj
 * Gaussian mixture using data to based on [this example](https://github.com/johnveitch/cpnest/blob/master/examples/gaussianmixture.py) from `cpnest`
 * n-dimensional Egg Box based on the version in [Feroz et al. 2008](https://arxiv.org/abs/0809.3437)
 * n-dimensional Pyramid-like model
+* Linear signal plus Gaussian noise model (`LinearSignal`)
+* Sinusoidal signal plus Gaussian noise model (`SinusoidalSignal`)
 
 ## Requirements
 

--- a/nessai_models/__init__.py
+++ b/nessai_models/__init__.py
@@ -19,6 +19,7 @@ from .gaussianmixture import GaussianMixture, GaussianMixtureWithData
 from .halfgaussian import HalfGaussian
 from .pyramid import Pyramid
 from .rosenbrock import Rosenbrock
+from .signals import LinearSignal, SinusoidalSignal
 
 __all__ = [
     "EggBox",
@@ -26,6 +27,8 @@ __all__ = [
     "GaussianMixture",
     "GaussianMixtureWithData",
     "HalfGaussian",
+    "LinearSignal",
     "Pyramid",
     "Rosenbrock",
+    "SinusoidalSignal",
 ]

--- a/nessai_models/signals.py
+++ b/nessai_models/signals.py
@@ -1,0 +1,152 @@
+"""Signal plus noise models."""
+from abc import abstractmethod
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from .base import BaseModel, UniformPriorMixin
+
+
+class GaussianNoisePlusSignal(UniformPriorMixin, BaseModel):
+    """Gaussian noise plus signal model.
+
+    Parameters
+    ----------
+    names : List[str]
+        Names of the parameters
+    truth : dict
+        Dictionary contain the true value for the injected signal.
+    sigma : float
+        Standard deviation of the Gaussian noise.
+    bounds : Dict
+        Prior bounds for the parameters.
+    n_points : int
+        The number of data points to use.
+    start : float
+        The starting x-value.
+    end : float
+        The ending x-value.
+    """
+
+    def __init__(
+        self,
+        names: List[str],
+        truth: Optional[Dict] = None,
+        sigma: float = 1.0,
+        bounds: Dict = None,
+        n_points: int = 100,
+        start: float = 0.0,
+        end: float = 1.0,
+    ) -> None:
+
+        self.names = names
+
+        if truth is None:
+            truth = {k: np.random.uniform(*v) for k, v in bounds.items()}
+        elif list(truth.keys()) != self.names:
+            raise ValueError("Keys in truth dictionary do not match names")
+
+        self.bounds = bounds
+        self.truth = truth
+        self.sigma = sigma
+
+        self.x = np.linspace(start, end, n_points)[:, np.newaxis]
+        self.data = self.signal_model(
+            **self.truth
+        ) + self.sigma * np.random.randn(n_points, 1)
+
+    @abstractmethod
+    def signal_model(self):
+        """Must be implemented by the child class.
+
+        Should be defined using named arguments.
+        """
+        raise NotImplementedError
+
+    def log_likelihood(self, x: np.ndarray) -> np.ndarray:
+        """Compute the log-likelihood"""
+        fits = self.signal_model(**{n: x[n] for n in self.names})
+        log_l = np.sum(
+            -0.5 * (((self.data - fits) / self.sigma) ** 2)
+            - np.log(2 * np.pi * self.sigma**2),
+            axis=0,
+        )
+        return log_l
+
+
+class LinearSignal(GaussianNoisePlusSignal):
+    """Linear signal model in Gaussian noise.
+    
+    Parameter names are: m, c
+    """
+
+    def __init__(
+        self,
+        truth: Optional[Dict] = None,
+        sigma: float = 1,
+        bounds: Optional[Dict] = None,
+        n_points: int = 100,
+        start: float = 0,
+        end: float = 10,
+    ) -> None:
+
+        names = ["m", "c"]
+        if bounds is None:
+            bounds = dict(
+                m=[-1, 1],
+                c=[-1, 1],
+            )
+
+        super().__init__(
+            names=names,
+            truth=truth,
+            sigma=sigma,
+            bounds=bounds,
+            n_points=n_points,
+            start=start,
+            end=end,
+        )
+
+    def signal_model(self, *, m, c) -> np.ndarray:
+        """Linear signal model."""
+        return m * self.x + c
+
+
+class SinusoidalSignal(GaussianNoisePlusSignal):
+    """Sinusoidal signal model in Gaussian noise.
+    
+    Parameter names are: amp, phase, f, offset
+    """
+
+    def __init__(
+        self,
+        truth: Optional[Dict] = None,
+        sigma: float = 1,
+        bounds: Optional[Dict] = None,
+        n_points: int = 100,
+        start: float = 0,
+        end: float = 10,
+    ) -> None:
+
+        names = ["amp", "phase", "f", "offset"]
+        if bounds is None:
+            bounds = dict(
+                amp=[0, 1],
+                f=[0, 5],
+                phase=[0, 2 * np.pi],
+                offset=[0, 5],
+            )
+
+        super().__init__(
+            names=names,
+            truth=truth,
+            sigma=sigma,
+            bounds=bounds,
+            n_points=n_points,
+            start=start,
+            end=end,
+        )
+
+    def signal_model(self, *, amp, f, phase, offset) -> np.ndarray:
+        """Sinusoidal signal model."""
+        return amp * np.sin(2 * np.pi * f * self.x + phase) + offset

--- a/nessai_models/signals.py
+++ b/nessai_models/signals.py
@@ -76,7 +76,7 @@ class GaussianNoisePlusSignal(UniformPriorMixin, BaseModel):
 
 class LinearSignal(GaussianNoisePlusSignal):
     """Linear signal model in Gaussian noise.
-    
+
     Parameter names are: m, c
     """
 
@@ -114,7 +114,7 @@ class LinearSignal(GaussianNoisePlusSignal):
 
 class SinusoidalSignal(GaussianNoisePlusSignal):
     """Sinusoidal signal model in Gaussian noise.
-    
+
     Parameter names are: amp, phase, f, offset
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,10 @@ from nessai_models import (
     GaussianMixture,
     GaussianMixtureWithData,
     HalfGaussian,
+    LinearSignal,
     Pyramid,
     Rosenbrock,
+    SinusoidalSignal,
 )
 import pytest
 
@@ -17,8 +19,10 @@ all_models = [
     GaussianMixture,
     GaussianMixtureWithData,
     HalfGaussian,
+    LinearSignal,
     Pyramid,
     Rosenbrock,
+    SinusoidalSignal,
 ]
 
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,33 @@
+"""Tests for signal-based models"""
+import numpy as np
+import pytest
+
+from nessai_models.signals import (
+    LinearSignal,
+    SinusoidalSignal,
+)
+
+all_models = [
+    LinearSignal,
+    SinusoidalSignal,
+]
+
+
+@pytest.fixture(params=all_models)
+def SignalModelClass(request):
+    """Signal model classes fixture."""
+    return request.param
+
+
+@pytest.mark.parametrize("n_points", [10, 100])
+@pytest.mark.parametrize("sigma", [1, 2])
+def test_max_likelihood(SignalModelClass, n_points, sigma):
+    """Assert the maximum likelihood is the correct value.
+
+    Sets the data to have zero noise.
+    """
+    model = SignalModelClass(n_points=n_points, sigma=sigma)
+    model.data = model.signal_model(**model.truth)
+    expected = n_points * -np.log(2 * np.pi * sigma**2)
+    actual = model.log_likelihood(model.truth)
+    np.testing.assert_almost_equal(actual, expected, decimal=12)


### PR DESCRIPTION
Add models with signals plus Gaussian noise.

New models:
* `SignalPlusGaussianNoise`: base model
* `LinearSignal`: `y = mx + c`
* `SinusoidalSignal`:  `y = amp * np.sin(2 * np.pi * f * x + phase) + offset`